### PR TITLE
Add IP address to status bar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ set (BRICKMAN_COMMON_SOURCE_FILES
     src/view/NetworkConnectionMenuItem.vala
     src/view/NetworkConnectionsWindow.vala
     src/view/NetworkPropertiesWindow.vala
+    src/view/NetworkStatusBarItem.vala
     src/view/NetworkStatusWindow.vala
     src/view/ShutdownDialog.vala
     src/view/USBWindow.vala

--- a/src/controller/NetworkController.vala
+++ b/src/controller/NetworkController.vala
@@ -36,6 +36,8 @@ namespace BrickManager {
 
         NetworkStatusWindow status_window;
         NetworkConnectionsWindow connections_window;
+        public NetworkStatusBarItem network_status_bar_item;
+        internal Binding status_bar_item_binding;
         ConnManAgent agent;
         Manager manager;
         Technology? wifi_technology;
@@ -62,6 +64,8 @@ namespace BrickManager {
                     critical ("%s", err.message);
                 }
             });
+
+            network_status_bar_item = new NetworkStatusBarItem();
         }
 
         async void init_async () throws IOError {
@@ -148,6 +152,10 @@ namespace BrickManager {
                     return true;
                 });
             }
+            if(status_bar_item_binding != null)
+                status_bar_item_binding.unbind();
+            status_bar_item_binding = null;
+
             changed.foreach ((service) => {
                 NetworkConnectionMenuItem menu_item;
                 if (service_map.has_key (service)) {
@@ -163,6 +171,15 @@ namespace BrickManager {
                     service_map[service] = menu_item;
                 }
                 connections_window.menu.add_menu_item (menu_item);
+
+                // Show the IP address of the primary service in the status bar
+                //      The list is ordered, so the first one is the one we want
+                if(status_bar_item_binding == null) {
+                    status_bar_item_binding = service.bind_property (
+                        "ipv4", network_status_bar_item, "text",
+                        BindingFlags.SYNC_CREATE, transform_service_ipv4_to_address_string);
+                }
+
             });
         }
 

--- a/src/main.vala
+++ b/src/main.vala
@@ -32,6 +32,7 @@ namespace BrickManager {
         var home_window = new HomeWindow ();
         var network_controller = new NetworkController ();
         home_window.add_controller (network_controller);
+        ConsoleApp.screen.status_bar.add_left (network_controller.network_status_bar_item);
         var usb_controller = new USBController ();
         home_window.add_controller (usb_controller);
         var battery_controller = new BatteryController ();

--- a/src/view/NetworkStatusBarItem.vala
+++ b/src/view/NetworkStatusBarItem.vala
@@ -1,0 +1,68 @@
+/*
+ * brickman -- Brick Manager for LEGO Mindstorms EV3/ev3dev
+ *
+ * Copyright (C) 2014 WasabiFan <wasabifan@outlook.com>
+ *
+ * based on BatteryStatusBarItem.vala
+ *   Copyright (C) 2014 David Lechner <david@lechnology.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * NetworkStatusBarItem.vala:
+ *
+ * Indicates network IP address in status bar
+ */
+
+using EV3devKit;
+using GRX;
+
+namespace BrickManager {
+    public class NetworkStatusBarItem : StatusBarItem {
+        const ushort TOP = 2;
+        static Font font;
+
+        static construct {
+            font =  Font.load ("xm6x8");
+        }
+
+        string _text = "";
+        TextOption text_option;
+
+        public string text {
+            get { return _text; }
+            set {
+                _text = value;
+                redraw();
+	    }
+        }
+
+        public NetworkStatusBarItem () {
+            text_option = new TextOption () {
+                font = NetworkStatusBarItem.font,
+                bg_color = Color.no_color
+            };
+        }
+
+        public override int draw (int x, StatusBar.Align align) {
+            var color = status_bar.screen.fg_color;
+            text_option.fg_color = color;
+            var main_width = text_option.vala_string_width(_text) + 2;
+
+            draw_vala_string (_text, x + 1, TOP, text_option);
+            return main_width;
+        }
+    }
+}

--- a/test/controller/FakeNetworkController.vala
+++ b/test/controller/FakeNetworkController.vala
@@ -32,6 +32,7 @@ namespace BrickManager {
         NetworkStatusWindow network_status_window;
         public Window start_window { get { return network_status_window; } }
         NetworkConnectionsWindow network_connections_window;
+        public NetworkStatusBarItem network_status_bar_item;
         ConnManAgent agent;
         Gtk.Dialog? agent_request_input_dialog;
 
@@ -94,6 +95,8 @@ namespace BrickManager {
                     connman_technology_liststore, toggle, path, ControlPanel.NetworkTechnologyColumn.CONNECTED));
 
             /* NetworkConnectionsWindow */
+            network_status_bar_item = new NetworkStatusBarItem();
+            network_status_bar_item.text = "192.168.137.3";
 
             network_connections_window = new NetworkConnectionsWindow ();
             bind_property ("has-wifi", network_connections_window, "has-wifi", BindingFlags.SYNC_CREATE);

--- a/test/main.vala
+++ b/test/main.vala
@@ -49,6 +49,8 @@ namespace BrickManager {
         home_window.add_controller (control_panel.about_controller);
         DesktopTestApp.screen.status_bar.add_right (
             control_panel.battery_controller.battery_status_bar_item);
+        DesktopTestApp.screen.status_bar.add_left (
+            control_panel.network_controller.network_status_bar_item);
         home_window.shutdown_dialog.power_off_button_pressed.connect (() =>
             DesktopTestApp.quit ());
         home_window.shutdown_dialog.reboot_button_pressed.connect (() => {


### PR DESCRIPTION
This addresses issue ev3dev/ev3dev#184.

@dlech Here's my attempt at adding the IP address. I tested it and the IP label successfully unbinds and rebinds when the IP address changes.

Unfortunately, I wasn't able to emulate the feature in the desktop test, so it just shows "???.???.???.???" so that you can see where it would be. If you would like me to try to get it to work on the desktop, I can give it another shot.
