### PR TITLE
Use /usr/bin/sudo instead of /sbin/runuser to launch processes from file browser

### DIFF
--- a/src/controller/FileBrowserController.vala
+++ b/src/controller/FileBrowserController.vala
@@ -86,8 +86,8 @@ namespace BrickManager {
                                 "--",
                                 "/bin/bash",
                                 "-c",
-                                "/usr/bin/tty >%s;tty=$(/bin/cat %s);/bin/chown %s: \$tty;/sbin/runuser --login --shell /bin/bash --command '(cd %s && exec %s)' %s"
-                                    .printf (ttyname_path, ttyname_path, USER_NAME, file.get_parent().get_path (), file.get_path (), USER_NAME),
+                                "/usr/bin/tty >%s;tty=$(/bin/cat %s);/bin/chown %s: \$tty;/usr/bin/sudo -u %s /bin/bash -c '(cd %s && exec %s)'"
+                                    .printf (ttyname_path, ttyname_path, USER_NAME, USER_NAME, file.get_parent().get_path (), file.get_path ()),
                             };
                             var subproc = new Subprocess.newv (args, SubprocessFlags.INHERIT_FDS);
                             global_manager.set_leds (LedState.USER);

--- a/src/controller/FileBrowserController.vala
+++ b/src/controller/FileBrowserController.vala
@@ -86,7 +86,7 @@ namespace BrickManager {
                                 "--",
                                 "/bin/bash",
                                 "-c",
-                                "/usr/bin/tty >%s;tty=$(/bin/cat %s);/bin/chown %s: \$tty;/usr/bin/sudo -u %s /bin/bash -c '(cd %s && exec %s)'"
+                                "/usr/bin/tty >%s;tty=$(/bin/cat %s);/bin/chown %s: \$tty;/usr/bin/sudo --login --non-interactive --user %s /bin/bash -c '(cd %s && exec %s)'"
                                     .printf (ttyname_path, ttyname_path, USER_NAME, USER_NAME, file.get_parent().get_path (), file.get_path ()),
                             };
                             var subproc = new Subprocess.newv (args, SubprocessFlags.INHERIT_FDS);


### PR DESCRIPTION
This should fix ev3dev/ev3dev#794.

This is not yet complete, as there is an unfinished discussion in ev3dev/ev3dev#794 re what exactly to do when the back key is long-pressed.