### PR TITLE
Improve synchronisation of the pairing code message.

### DIFF
--- a/src/controller/OpenRobertaController.vala
+++ b/src/controller/OpenRobertaController.vala
@@ -147,7 +147,7 @@ namespace BrickManager {
                         chvt (tty_num);
                     } else {
                         debug ("connection established, closing the dialog");
-                        OpenRobertaWindow.close_pairing_code_dialog ();
+                        OpenRobertaWindow.close_connection_dialog ();
                         // remember selected server
                         config.set_string ("Common", "SelectedServer",
                             open_roberta_window.selected_server);
@@ -168,7 +168,7 @@ namespace BrickManager {
                 open_roberta_window.connected = false;
                 if (message == "disconnected") {
                     debug ("connection failed, closing the dialog");
-                    OpenRobertaWindow.close_pairing_code_dialog ();
+                    OpenRobertaWindow.close_connection_dialog ();
                 }
             }
         }
@@ -186,8 +186,13 @@ namespace BrickManager {
         void on_server_connect (string address) {
             try {
                 open_roberta_window.selected_server = address;
-                var code = service.connect ("http://" + address);
-                OpenRobertaWindow.show_pairing_code_dialog (code);
+                OpenRobertaWindow.show_connection_dialog ("Connect to server", "Connecting ...");
+                Idle.add (() => {
+                    var code = service.connect ("http://" + address);
+                    OpenRobertaWindow.close_connection_dialog ();
+                    OpenRobertaWindow.show_connection_dialog ("Pairing code", code);
+                    return Source.REMOVE;
+                });
             } catch (IOError err) {
                 warning ("%s", err.message);
             }

--- a/src/main.vala
+++ b/src/main.vala
@@ -32,7 +32,12 @@ namespace BrickManager {
     // The global_manager is shared by all of the controller objects
     GlobalManager global_manager;
 
-     public static int main (string[] args) {
+    public static int main (string[] args) {
+        if (args.length > 1 && args[1] == "--version") {
+            Posix.stdout.printf("%s v%s\n", EXEC_NAME, VERSION);
+            Process.exit (0);
+        }
+
         try {
             ConsoleApp.init ();
         } catch (ConsoleApp.ConsoleAppError err) {

--- a/src/view/OpenRobertaWindow.vala
+++ b/src/view/OpenRobertaWindow.vala
@@ -160,12 +160,12 @@ namespace BrickManager {
             dialog.show ();
         }
 
-        public static void show_pairing_code_dialog (string code) {
-            var label = new Label (code) {
+        public static void show_connection_dialog (string title, string message) {
+            var label = new Label (message) {
                 margin_top = 12,
                 font = Fonts.get_big ()
             };
-            pin_dialog = new MessageDialog.with_content ("Pairing code", label);
+            pin_dialog = new MessageDialog.with_content (title, label);
             ulong pin_dialog_closed_id = 0;
             pin_dialog_closed_id = pin_dialog.closed.connect (() => {
                 pin_dialog.disconnect (pin_dialog_closed_id);
@@ -174,7 +174,7 @@ namespace BrickManager {
             pin_dialog.show ();
         }
 
-        public static void close_pairing_code_dialog () {
+        public static void close_connection_dialog () {
             if (pin_dialog != null) {
                 pin_dialog.close ();
             }


### PR DESCRIPTION
We did send the code to the server and showed the code at the same time.
This will let the user enter the code before we managed to connect. Now
we show a "connecting..." message first and only show the code when we
conencted.
See OpenRoberta/robertalab-ev3dev#30