### PR TITLE
Update bullseye submodule and cloning to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cmake"]
 	path = cmake
-	url = git://github.com/dlech/vala-cmake-modules
+	url = https://github.com/dlech/vala-cmake-modules

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Get the code:
 
 * Clone of the brickman repo.
 
-        git clone git://github.com/ev3dev/brickman
+        git clone https://github.com/ev3dev/brickman
         cd brickman
         git submodule update --init --recursive
 


### PR DESCRIPTION
Notes:
* This is because GitLab has removed support for the insecure 'git://' protocol